### PR TITLE
Enabling Port Configuration and override (CSD-6189)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 docker-compose.*.yml
 !docker-compose.disable-user-access.yml
 !docker-compose.sample-db-config.yml
+!docker-compose.port-configuration.yml
 
 # Other
 **.swp

--- a/docker-compose.port-configuration.yml
+++ b/docker-compose.port-configuration.yml
@@ -18,12 +18,16 @@ services:
       - 8080:8080
     expose:
       - 8080
+    healthcheck: 
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
 
   webcsdbackend:
     environment:
       - ASPNETCORE_URLS=http://+:8080
     expose:
       - 8080
+    healthcheck: 
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
 
   redis:
     expose:
@@ -42,18 +46,25 @@ services:
       - ASPNETCORE_URLS=http://+:8080
     expose:
       - 8080
+    healthcheck: 
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
       
   ccdc-csd-deposition:
     environment:
       - ASPNETCORE_URLS=http://+:8080
     expose:
       - 8080
+    healthcheck: 
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
+      
 
   ccdc-csd-textnumericsearch:
     environment:      
       - ASPNETCORE_URLS=http://+:8080
     expose:
       - 8080
+    healthcheck: 
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
       
   ccdc-csd-searchservice:
     environment:
@@ -67,7 +78,9 @@ services:
       - ASPNETCORE_URLS=http://+:8080
     expose:
       - 8080
-      
+    healthcheck: 
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
+
   csd-request-entry:
     environment:
       - CrystalStructureExportService=http://ccdc-csd-crystal-structure-export:8080
@@ -75,12 +88,16 @@ services:
       - ASPNETCORE_URLS=http://+:8080
     expose:
       - 8080
+    healthcheck: 
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
  
   ccdc-csd-formulasearch:
     environment:
       - ASPNETCORE_URLS=http://+:8080
     expose:
       - 8080
+    healthcheck: 
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
 
   ccdc-csd-unitcellsearch:
     environment:
@@ -89,12 +106,16 @@ services:
       - ASPNETCORE_URLS=http://+:8080
     expose:
       - 8080
+    healthcheck: 
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
       
   ccdc-csd-resultstore:
     environment:
       - ASPNETCORE_URLS=http://+:8080
     expose:
       - 8080
+    healthcheck: 
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
       
   ccdc-csd-similaritysearch:
     environment:
@@ -102,30 +123,40 @@ services:
       - ASPNETCORE_URLS=http://+:8080
     expose:
       - 8080
+    healthcheck: 
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
       
   ccdc-csd-substructure-filter:
     environment:
-      - ASPNETCORE_URLS=http://+:8080
+      - CCDC_SERVICE_PORT=8080
     expose:
       - 8080
+    healthcheck: 
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
       
   ccdc-csd-crystal-structure-export:
     environment:
       - CCDC_SERVICE_PORT=8080
     expose:
-      - 8080     
+      - 8080   
+    healthcheck: 
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"  
       
   ccdc-csd-reducedcell-calculation-service:
     environment:
       - CCDC_SERVICE_PORT=8080
     expose:
       - 8080          
+    healthcheck: 
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
 
   ccdc-csd-fingerprint:
     environment:
       - CCDC_SERVICE_PORT=8080
     expose:
       - 8080
+    healthcheck: 
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
 
   
   

--- a/docker-compose.port-configuration.yml
+++ b/docker-compose.port-configuration.yml
@@ -157,7 +157,3 @@ services:
       - 8080
     healthcheck: 
       test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
-
-  
-  
-  #Healthchecks - all

--- a/docker-compose.port-configuration.yml
+++ b/docker-compose.port-configuration.yml
@@ -163,5 +163,6 @@ services:
   webcsd-theory:
     environment:
       - ASPNETCORE_URLS=http://+:8080
+      - ReportSettings__CspServerUrl=localhost:8080
     expose:
       - 8080

--- a/docker-compose.port-configuration.yml
+++ b/docker-compose.port-configuration.yml
@@ -14,6 +14,8 @@ services:
       - CsdRepository__UnitCellSearchLocation=http://ccdc-csd-searchservice:8080/
       - CsdRepository__ServiceLocation=webcsdbackend:8080
       - ASPNETCORE_URLS=http://+:8080
+      - CspRepository__ServiceLocation=webcsd-theory:8080
+
     ports:
       - 8080:8080
     expose:
@@ -153,6 +155,14 @@ services:
   ccdc-csd-fingerprint:
     environment:
       - CCDC_SERVICE_PORT=8080
+    expose:
+      - 8080
+    healthcheck: 
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
+
+  webcsd-theory:
+    environment:
+      - ASPNETCORE_URLS=http://+:8080
     expose:
       - 8080
     healthcheck: 

--- a/docker-compose.port-configuration.yml
+++ b/docker-compose.port-configuration.yml
@@ -165,5 +165,3 @@ services:
       - ASPNETCORE_URLS=http://+:8080
     expose:
       - 8080
-    healthcheck: 
-      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"

--- a/docker-compose.port-configuration.yml
+++ b/docker-compose.port-configuration.yml
@@ -1,0 +1,132 @@
+version: "3.6"
+
+services:
+  webcsd:
+    environment:
+      - CsdRepository__SearchServiceLocation=http://ccdc-csd-searchservice:8080/
+      - CsdRepository__PagedResultLocation=http://ccdc-csd-searchservice:8080/
+      - CsdRepository__RequestEntriesServiceLocation=http://csd-request-entry:8080/
+      - CsdRepository__ChemicalDiagramImageLocation=http://csd-request-entry:8080/
+      - CsdRepository__ChemicalStructureMol2Location=http://csd-request-entry:8080/
+      - CsdRepository__AtomEquivalencesLocation=http://csd-request-entry:8080/
+      - CsdRepository__FormulaSearchServiceLocation=http://ccdc-csd-searchservice:8080/
+      - CsdRepository__StructureSimilaritySearchServiceLocation=http://ccdc-csd-searchservice:8080/
+      - CsdRepository__UnitCellSearchLocation=http://ccdc-csd-searchservice:8080/
+      - CsdRepository__ServiceLocation=webcsdbackend:8080
+      - ASPNETCORE_URLS=http://+:8080
+    ports:
+      - 8080:8080
+    expose:
+      - 8080
+
+  webcsdbackend:
+    environment:
+      - ASPNETCORE_URLS=http://+:8080
+    expose:
+      - 8080
+
+  redis:
+    expose:
+      - 6379
+  
+  database-server:
+    expose:
+      - 5432
+      
+  ccdc-csd-substructuresearch:
+    environment:
+      - FingerprintCalculationService=http://ccdc-csd-fingerprint:8080
+      - ResultsStoreService=http://ccdc-csd-resultstore:8080
+      - DepositionService=http://ccdc-csd-deposition:8080
+      - SubstructureFilterService=http://ccdc-csd-substructure-filter:8080
+      - ASPNETCORE_URLS=http://+:8080
+    expose:
+      - 8080
+      
+  ccdc-csd-deposition:
+    environment:
+      - ASPNETCORE_URLS=http://+:8080
+    expose:
+      - 8080
+
+  ccdc-csd-textnumericsearch:
+    environment:      
+      - ASPNETCORE_URLS=http://+:8080
+    expose:
+      - 8080
+      
+  ccdc-csd-searchservice:
+    environment:
+      - TextNumericSearchService=http://ccdc-csd-textnumericsearch:8080/
+      - SubstructureSearchService=http://ccdc-csd-substructuresearch:8080/
+      - QueryIdGeneratorService=http://ccdc-csd-resultstore:8080/
+      - PagedResultsService=http://ccdc-csd-resultstore:8080/
+      - FormulaSearchService=http://ccdc-csd-formulasearch:8080/
+      - StructureSimilaritySearchService=http://ccdc-csd-similaritysearch:8080/
+      - UnitCellSearchService=http://ccdc-csd-unitcellsearch:8080/
+      - ASPNETCORE_URLS=http://+:8080
+    expose:
+      - 8080
+      
+  csd-request-entry:
+    environment:
+      - CrystalStructureExportService=http://ccdc-csd-crystal-structure-export:8080
+      - DepositionService=http://ccdc-csd-deposition:8080
+      - ASPNETCORE_URLS=http://+:8080
+    expose:
+      - 8080
+ 
+  ccdc-csd-formulasearch:
+    environment:
+      - ASPNETCORE_URLS=http://+:8080
+    expose:
+      - 8080
+
+  ccdc-csd-unitcellsearch:
+    environment:
+      - UnitCellNiggliReducedCellCalculationService=http://ccdc-csd-reducedcell-calculation-service:8080
+      - UnitCellReducedCellCalculationService=http://ccdc-csd-reducedcell-calculation-service:8080
+      - ASPNETCORE_URLS=http://+:8080
+    expose:
+      - 8080
+      
+  ccdc-csd-resultstore:
+    environment:
+      - ASPNETCORE_URLS=http://+:8080
+    expose:
+      - 8080
+      
+  ccdc-csd-similaritysearch:
+    environment:
+      - FingerprintChemicalDiagramCalculationService=http://ccdc-csd-fingerprint:8080
+      - ASPNETCORE_URLS=http://+:8080
+    expose:
+      - 8080
+      
+  ccdc-csd-substructure-filter:
+    environment:
+      - ASPNETCORE_URLS=http://+:8080
+    expose:
+      - 8080
+      
+  ccdc-csd-crystal-structure-export:
+    environment:
+      - CCDC_SERVICE_PORT=8080
+    expose:
+      - 8080     
+      
+  ccdc-csd-reducedcell-calculation-service:
+    environment:
+      - CCDC_SERVICE_PORT=8080
+    expose:
+      - 8080          
+
+  ccdc-csd-fingerprint:
+    environment:
+      - CCDC_SERVICE_PORT=8080
+    expose:
+      - 8080
+
+  
+  
+  #Healthchecks - all


### PR DESCRIPTION
This will enable customers to override our default port 80 for all services to use what ever port is more appropriate for them.

I have included the Database Server and Redis for completeness but we don't think these will need to change and aren't running on port 80.

The WIKI will be updated separately