### PR TITLE
WCSD-3452 Port configuration fix

### DIFF
--- a/docker-compose.macromolecule-hub.yml
+++ b/docker-compose.macromolecule-hub.yml
@@ -12,7 +12,7 @@ services:
     depends_on:
       - ccdc-csd-searchservice
       - csd-request-entry
-    image: ccdcrepository.azurecr.io/onsite/webcsd:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/webcsd:3.0.0
     ports:
       - ${WEBCSD_PORT}:${WEBCSD_PORT}
     volumes:
@@ -26,7 +26,7 @@ services:
     depends_on:
       - ccdc-csd-searchservice
       - csd-request-entry
-    image: ccdcrepository.azurecr.io/onsite/webcsdbackend:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/webcsdbackend:3.0.0
     environment:
       - ServiceSettings__StructureInfoLocation=/csd-data/structure-links.csv
       - CCDC_LICENSING_CONFIGURATION=${CCDC_LICENSING_CONFIGURATION}
@@ -65,7 +65,7 @@ services:
   ccdc-csd-substructuresearch:
     labels:
       <<: *k8s-labels
-    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-substructuresearch-api:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-substructuresearch-api:3.0.0
     depends_on:
       - database-server
       - ccdc-csd-resultstore
@@ -81,7 +81,7 @@ services:
   ccdc-csd-deposition:
     labels:
       <<: *k8s-labels
-    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-deposition-api:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-deposition-api:3.0.0
     depends_on:
       - database-server
     environment:
@@ -95,7 +95,7 @@ services:
       <<: *k8s-labels
     depends_on:
       - database-server
-    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-textnumericsearch-api:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-textnumericsearch-api:3.0.0
     environment:
       - CsdReadConnection=Server=database-server;Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=csd_schema
       - PdbReadConnection=Server=database-server;Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=pdb_schema
@@ -110,7 +110,7 @@ services:
       - ccdc-csd-substructuresearch
       - ccdc-csd-resultstore
       - ccdc-csd-similaritysearch
-    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-searchservice-api:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-searchservice-api:3.0.0
 
   csd-request-entry:
     labels:
@@ -118,14 +118,14 @@ services:
     depends_on:
       - ccdc-csd-deposition
       - ccdc-csd-crystal-structure-export
-    image: ccdcrepository.azurecr.io/onsite/csd-request-entry-api:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/csd-request-entry-api:3.0.0
 
   ccdc-csd-formulasearch:
     labels:
       <<: *k8s-labels
     depends_on:
       - database-server
-    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-formulasearch-api:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-formulasearch-api:3.0.0
     environment:
       - FormulaSearchReadConnection=Server=database-server;Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=formula
 
@@ -135,7 +135,7 @@ services:
     depends_on:
       - database-server
       - ccdc-csd-reducedcell-calculation-service
-    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-unit-cell-search:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-unit-cell-search:3.0.0
     environment:
       - UnitCellSearchReadConnection=Server=database-server;Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=unitcell
       - UnitCellPdbReadConnection=Server=database-server;Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=pdb_cell_optimisation
@@ -145,7 +145,7 @@ services:
   ccdc-csd-resultstore:
     labels:
       <<: *k8s-labels
-    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-resultstore-api:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-resultstore-api:3.0.0
     environment:
       - OrderedCachePassword=${CSD_CACHE_PASSWORD}
 
@@ -153,38 +153,38 @@ services:
     depends_on:
       - database-server
       - ccdc-csd-fingerprint
-    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-structure-similarity-search:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-structure-similarity-search:3.0.0
     environment:
       - StructureSimilaritySearchReadConnection=Server=database-server;Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=similarity
 
   ccdc-csd-fingerprint:
     labels:
       <<: *k8s-labels
-    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-fingerprint-service:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-fingerprint-service:3.0.0
     restart: unless-stopped
 
   ccdc-csd-substructure-filter:
     labels:
       <<: *k8s-labels
-    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-substructure-filter-service:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-substructure-filter-service:3.0.0
     restart: unless-stopped
 
   ccdc-csd-crystal-structure-export:
     labels:
       <<: *k8s-labels
-    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-crystal-structure-export-service:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-crystal-structure-export-service:3.0.0
     restart: unless-stopped
 
   ccdc-csd-reducedcell-calculation-service:
     labels:
       <<: *k8s-labels
-    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-reducedcell-calculation-service:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-reducedcell-calculation-service:3.0.0
     restart: unless-stopped
 
   webcsd-theory:
     labels:
       <<: *k8s-labels
-    image: ccdcrepository.azurecr.io/onsite/csd-theory:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/csd-theory:3.0.0
     environment:
       - CCDC_LICENSING_CONFIGURATION=${CCDC_LICENSING_CONFIGURATION}
 

--- a/docker-compose.macromolecule-hub.yml
+++ b/docker-compose.macromolecule-hub.yml
@@ -14,7 +14,7 @@ services:
       - csd-request-entry
     image: ccdcrepository.azurecr.io/onsite/webcsd:2.1.0
     ports:
-      - 80:80
+      - ${WEBCSD_PORT}:${WEBCSD_PORT}
     volumes:
       - ./userdata:/app/OnSite
     labels:
@@ -35,8 +35,6 @@ services:
       - ServiceSettings__Databases__1__ConnectionString=dbe
     labels:
       <<: *k8s-labels
-    expose:
-      - 80
 
   redis:
     labels:
@@ -79,8 +77,6 @@ services:
       - PdbReadConnection=Server=database-server;Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=structure_optimisation
       - SubstructureSearchDatabaseConfiguration__Databases__1__Name=pdb
       - SubstructureSearchDatabaseConfiguration__Databases__1__SettingsKey=PdbReadConnection
-    expose:
-      - 80
 
   ccdc-csd-deposition:
     labels:
@@ -93,8 +89,6 @@ services:
       - DepositionPdbReadConnection=Server=database-server;Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=pdb_schema
       - DatabaseConfiguration__Databases__1__Name=pdb
       - DatabaseConfiguration__Databases__1__SettingsKey=DepositionPdbReadConnection
-    expose:
-      - 80
 
   ccdc-csd-textnumericsearch:
     labels:
@@ -107,8 +101,6 @@ services:
       - PdbReadConnection=Server=database-server;Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=pdb_schema
       - DatabaseConfiguration__Databases__1__Name=pdb
       - DatabaseConfiguration__Databases__1__SettingsKey=PdbReadConnection
-    expose:
-      - 80
 
   ccdc-csd-searchservice:
     labels:
@@ -119,8 +111,6 @@ services:
       - ccdc-csd-resultstore
       - ccdc-csd-similaritysearch
     image: ccdcrepository.azurecr.io/onsite/ccdc-csd-searchservice-api:2.1.0
-    expose:
-      - 80
 
   csd-request-entry:
     labels:
@@ -129,8 +119,6 @@ services:
       - ccdc-csd-deposition
       - ccdc-csd-crystal-structure-export
     image: ccdcrepository.azurecr.io/onsite/csd-request-entry-api:2.1.0
-    expose:
-      - 80
 
   ccdc-csd-formulasearch:
     labels:
@@ -140,8 +128,6 @@ services:
     image: ccdcrepository.azurecr.io/onsite/ccdc-csd-formulasearch-api:2.1.0
     environment:
       - FormulaSearchReadConnection=Server=database-server;Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=formula
-    expose:
-      - 80
 
   ccdc-csd-unitcellsearch:
     labels:
@@ -155,8 +141,6 @@ services:
       - UnitCellPdbReadConnection=Server=database-server;Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=pdb_cell_optimisation
       - DatabaseConfiguration__Databases__1__Name=pdb
       - DatabaseConfiguration__Databases__1__SettingsKey=UnitCellPdbReadConnection
-    expose:
-      - 80
 
   ccdc-csd-resultstore:
     labels:
@@ -164,8 +148,6 @@ services:
     image: ccdcrepository.azurecr.io/onsite/ccdc-csd-resultstore-api:2.1.0
     environment:
       - OrderedCachePassword=${CSD_CACHE_PASSWORD}
-    expose:
-      - 80
 
   ccdc-csd-similaritysearch:
     depends_on:
@@ -179,32 +161,24 @@ services:
     labels:
       <<: *k8s-labels
     image: ccdcrepository.azurecr.io/onsite/ccdc-csd-fingerprint-service:2.1.0
-    expose:
-      - 80
     restart: unless-stopped
 
   ccdc-csd-substructure-filter:
     labels:
       <<: *k8s-labels
     image: ccdcrepository.azurecr.io/onsite/ccdc-csd-substructure-filter-service:2.1.0
-    expose:
-      - 80
     restart: unless-stopped
 
   ccdc-csd-crystal-structure-export:
     labels:
       <<: *k8s-labels
     image: ccdcrepository.azurecr.io/onsite/ccdc-csd-crystal-structure-export-service:2.1.0
-    expose:
-      - 80
     restart: unless-stopped
 
   ccdc-csd-reducedcell-calculation-service:
     labels:
       <<: *k8s-labels
     image: ccdcrepository.azurecr.io/onsite/ccdc-csd-reducedcell-calculation-service:2.1.0
-    expose:
-      - 80
     restart: unless-stopped
 
   webcsd-theory:
@@ -213,8 +187,6 @@ services:
     image: ccdcrepository.azurecr.io/onsite/csd-theory:2.1.0
     environment:
       - CCDC_LICENSING_CONFIGURATION=${CCDC_LICENSING_CONFIGURATION}
-    expose:
-      - 80
 
 volumes:
   csd_data: {}

--- a/docker-compose.port-configuration.yml
+++ b/docker-compose.port-configuration.yml
@@ -3,33 +3,30 @@ version: "3.6"
 services:
   webcsd:
     environment:
-      - CsdRepository__SearchServiceLocation=http://ccdc-csd-searchservice:8080/
-      - CsdRepository__PagedResultLocation=http://ccdc-csd-searchservice:8080/
-      - CsdRepository__RequestEntriesServiceLocation=http://csd-request-entry:8080/
-      - CsdRepository__ChemicalDiagramImageLocation=http://csd-request-entry:8080/
-      - CsdRepository__ChemicalStructureMol2Location=http://csd-request-entry:8080/
-      - CsdRepository__AtomEquivalencesLocation=http://csd-request-entry:8080/
-      - CsdRepository__FormulaSearchServiceLocation=http://ccdc-csd-searchservice:8080/
-      - CsdRepository__StructureSimilaritySearchServiceLocation=http://ccdc-csd-searchservice:8080/
-      - CsdRepository__UnitCellSearchLocation=http://ccdc-csd-searchservice:8080/
-      - CsdRepository__ServiceLocation=webcsdbackend:8080
-      - ASPNETCORE_URLS=http://+:8080
-      - CspRepository__ServiceLocation=webcsd-theory:8080
-
-    ports:
-      - 8080:8080
+      - CsdRepository__SearchServiceLocation=http://ccdc-csd-searchservice:${WEBCSD_PORT}/
+      - CsdRepository__PagedResultLocation=http://ccdc-csd-searchservice:${WEBCSD_PORT}/
+      - CsdRepository__RequestEntriesServiceLocation=http://csd-request-entry:${WEBCSD_PORT}/
+      - CsdRepository__ChemicalDiagramImageLocation=http://csd-request-entry:${WEBCSD_PORT}/
+      - CsdRepository__ChemicalStructureMol2Location=http://csd-request-entry:${WEBCSD_PORT}/
+      - CsdRepository__AtomEquivalencesLocation=http://csd-request-entry:${WEBCSD_PORT}/
+      - CsdRepository__FormulaSearchServiceLocation=http://ccdc-csd-searchservice:${WEBCSD_PORT}/
+      - CsdRepository__StructureSimilaritySearchServiceLocation=http://ccdc-csd-searchservice:${WEBCSD_PORT}/
+      - CsdRepository__UnitCellSearchLocation=http://ccdc-csd-searchservice:${WEBCSD_PORT}/
+      - CsdRepository__ServiceLocation=webcsdbackend:${WEBCSD_PORT}
+      - ASPNETCORE_URLS=http://+:${WEBCSD_PORT}
+      - CspRepository__ServiceLocation=webcsd-theory:${WEBCSD_PORT}
     expose:
-      - 8080
+      - ${WEBCSD_PORT}
     healthcheck: 
-      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:${WEBCSD_PORT}/health/ready"
 
   webcsdbackend:
     environment:
-      - ASPNETCORE_URLS=http://+:8080
+      - ASPNETCORE_URLS=http://+:${WEBCSD_PORT}
     expose:
-      - 8080
+      - ${WEBCSD_PORT}
     healthcheck: 
-      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:${WEBCSD_PORT}/health/ready"
 
   redis:
     expose:
@@ -41,128 +38,128 @@ services:
       
   ccdc-csd-substructuresearch:
     environment:
-      - FingerprintCalculationService=http://ccdc-csd-fingerprint:8080
-      - ResultsStoreService=http://ccdc-csd-resultstore:8080
-      - DepositionService=http://ccdc-csd-deposition:8080
-      - SubstructureFilterService=http://ccdc-csd-substructure-filter:8080
-      - ASPNETCORE_URLS=http://+:8080
+      - FingerprintCalculationService=http://ccdc-csd-fingerprint:${WEBCSD_PORT}
+      - ResultsStoreService=http://ccdc-csd-resultstore:${WEBCSD_PORT}
+      - DepositionService=http://ccdc-csd-deposition:${WEBCSD_PORT}
+      - SubstructureFilterService=http://ccdc-csd-substructure-filter:${WEBCSD_PORT}
+      - ASPNETCORE_URLS=http://+:${WEBCSD_PORT}
     expose:
-      - 8080
+      - ${WEBCSD_PORT}
     healthcheck: 
-      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:${WEBCSD_PORT}/health/ready"
       
   ccdc-csd-deposition:
     environment:
-      - ASPNETCORE_URLS=http://+:8080
+      - ASPNETCORE_URLS=http://+:${WEBCSD_PORT}
     expose:
-      - 8080
+      - ${WEBCSD_PORT}
     healthcheck: 
-      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:${WEBCSD_PORT}/health/ready"
       
 
   ccdc-csd-textnumericsearch:
     environment:      
-      - ASPNETCORE_URLS=http://+:8080
+      - ASPNETCORE_URLS=http://+:${WEBCSD_PORT}
     expose:
-      - 8080
+      - ${WEBCSD_PORT}
     healthcheck: 
-      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:${WEBCSD_PORT}/health/ready"
       
   ccdc-csd-searchservice:
     environment:
-      - TextNumericSearchService=http://ccdc-csd-textnumericsearch:8080/
-      - SubstructureSearchService=http://ccdc-csd-substructuresearch:8080/
-      - QueryIdGeneratorService=http://ccdc-csd-resultstore:8080/
-      - PagedResultsService=http://ccdc-csd-resultstore:8080/
-      - FormulaSearchService=http://ccdc-csd-formulasearch:8080/
-      - StructureSimilaritySearchService=http://ccdc-csd-similaritysearch:8080/
-      - UnitCellSearchService=http://ccdc-csd-unitcellsearch:8080/
-      - ASPNETCORE_URLS=http://+:8080
+      - TextNumericSearchService=http://ccdc-csd-textnumericsearch:${WEBCSD_PORT}/
+      - SubstructureSearchService=http://ccdc-csd-substructuresearch:${WEBCSD_PORT}/
+      - QueryIdGeneratorService=http://ccdc-csd-resultstore:${WEBCSD_PORT}/
+      - PagedResultsService=http://ccdc-csd-resultstore:${WEBCSD_PORT}/
+      - FormulaSearchService=http://ccdc-csd-formulasearch:${WEBCSD_PORT}/
+      - StructureSimilaritySearchService=http://ccdc-csd-similaritysearch:${WEBCSD_PORT}/
+      - UnitCellSearchService=http://ccdc-csd-unitcellsearch:${WEBCSD_PORT}/
+      - ASPNETCORE_URLS=http://+:${WEBCSD_PORT}
     expose:
-      - 8080
+      - ${WEBCSD_PORT}
     healthcheck: 
-      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:${WEBCSD_PORT}/health/ready"
 
   csd-request-entry:
     environment:
-      - CrystalStructureExportService=http://ccdc-csd-crystal-structure-export:8080
-      - DepositionService=http://ccdc-csd-deposition:8080
-      - ASPNETCORE_URLS=http://+:8080
+      - CrystalStructureExportService=http://ccdc-csd-crystal-structure-export:${WEBCSD_PORT}
+      - DepositionService=http://ccdc-csd-deposition:${WEBCSD_PORT}
+      - ASPNETCORE_URLS=http://+:${WEBCSD_PORT}
     expose:
-      - 8080
+      - ${WEBCSD_PORT}
     healthcheck: 
-      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:${WEBCSD_PORT}/health/ready"
  
   ccdc-csd-formulasearch:
     environment:
-      - ASPNETCORE_URLS=http://+:8080
+      - ASPNETCORE_URLS=http://+:${WEBCSD_PORT}
     expose:
-      - 8080
+      - ${WEBCSD_PORT}
     healthcheck: 
-      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:${WEBCSD_PORT}/health/ready"
 
   ccdc-csd-unitcellsearch:
     environment:
-      - UnitCellNiggliReducedCellCalculationService=http://ccdc-csd-reducedcell-calculation-service:8080
-      - UnitCellReducedCellCalculationService=http://ccdc-csd-reducedcell-calculation-service:8080
-      - ASPNETCORE_URLS=http://+:8080
+      - UnitCellNiggliReducedCellCalculationService=http://ccdc-csd-reducedcell-calculation-service:${WEBCSD_PORT}
+      - UnitCellReducedCellCalculationService=http://ccdc-csd-reducedcell-calculation-service:${WEBCSD_PORT}
+      - ASPNETCORE_URLS=http://+:${WEBCSD_PORT}
     expose:
-      - 8080
+      - ${WEBCSD_PORT}
     healthcheck: 
-      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:${WEBCSD_PORT}/health/ready"
       
   ccdc-csd-resultstore:
     environment:
-      - ASPNETCORE_URLS=http://+:8080
+      - ASPNETCORE_URLS=http://+:${WEBCSD_PORT}
     expose:
-      - 8080
+      - ${WEBCSD_PORT}
     healthcheck: 
-      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:${WEBCSD_PORT}/health/ready"
       
   ccdc-csd-similaritysearch:
     environment:
-      - FingerprintChemicalDiagramCalculationService=http://ccdc-csd-fingerprint:8080
-      - ASPNETCORE_URLS=http://+:8080
+      - FingerprintChemicalDiagramCalculationService=http://ccdc-csd-fingerprint:${WEBCSD_PORT}
+      - ASPNETCORE_URLS=http://+:${WEBCSD_PORT}
     expose:
-      - 8080
+      - ${WEBCSD_PORT}
     healthcheck: 
-      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:${WEBCSD_PORT}/health/ready"
       
   ccdc-csd-substructure-filter:
     environment:
-      - CCDC_SERVICE_PORT=8080
+      - CCDC_SERVICE_PORT=${WEBCSD_PORT}
     expose:
-      - 8080
+      - ${WEBCSD_PORT}
     healthcheck: 
-      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:${WEBCSD_PORT}/health/ready"
       
   ccdc-csd-crystal-structure-export:
     environment:
-      - CCDC_SERVICE_PORT=8080
+      - CCDC_SERVICE_PORT=${WEBCSD_PORT}
     expose:
-      - 8080   
+      - ${WEBCSD_PORT}   
     healthcheck: 
-      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"  
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:${WEBCSD_PORT}/health/ready"  
       
   ccdc-csd-reducedcell-calculation-service:
     environment:
-      - CCDC_SERVICE_PORT=8080
+      - CCDC_SERVICE_PORT=${WEBCSD_PORT}
     expose:
-      - 8080          
+      - ${WEBCSD_PORT}          
     healthcheck: 
-      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:${WEBCSD_PORT}/health/ready"
 
   ccdc-csd-fingerprint:
     environment:
-      - CCDC_SERVICE_PORT=8080
+      - CCDC_SERVICE_PORT=${WEBCSD_PORT}
     expose:
-      - 8080
+      - ${WEBCSD_PORT}
     healthcheck: 
-      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:8080/health/ready"
+      test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:${WEBCSD_PORT}/health/ready"
 
   webcsd-theory:
     environment:
-      - ASPNETCORE_URLS=http://+:8080
-      - ReportSettings__CspServerUrl=localhost:8080
+      - ReportSettings__CspServerUrl=localhost:${WEBCSD_PORT}
+      - ASPNETCORE_URLS=http://+:${WEBCSD_PORT}
     expose:
-      - 8080
+      - ${WEBCSD_PORT}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     depends_on:
       - ccdc-csd-searchservice
       - csd-request-entry
-    image: ccdcrepository.azurecr.io/onsite/webcsd:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/webcsd:3.0.0
     ports:
       - ${WEBCSD_PORT}:${WEBCSD_PORT}
     volumes:
@@ -25,7 +25,7 @@ services:
     depends_on:
       - ccdc-csd-searchservice
       - csd-request-entry
-    image: ccdcrepository.azurecr.io/onsite/webcsdbackend:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/webcsdbackend:3.0.0
     environment:
       - ServiceSettings__StructureInfoLocation=/csd-data/structure-links.csv
       - CCDC_LICENSING_CONFIGURATION=${CCDC_LICENSING_CONFIGURATION}
@@ -61,7 +61,7 @@ services:
   ccdc-csd-substructuresearch:
     labels:
       <<: *k8s-labels
-    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-substructuresearch-api:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-substructuresearch-api:3.0.0
     depends_on:
       - database-server
       - ccdc-csd-resultstore
@@ -74,7 +74,7 @@ services:
   ccdc-csd-deposition:
     labels:
       <<: *k8s-labels
-    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-deposition-api:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-deposition-api:3.0.0
     depends_on:
       - database-server
     environment:
@@ -85,7 +85,7 @@ services:
       <<: *k8s-labels
     depends_on:
       - database-server
-    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-textnumericsearch-api:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-textnumericsearch-api:3.0.0
     environment:
       - CsdReadConnection=Server=database-server;Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=csd_schema
 
@@ -97,7 +97,7 @@ services:
       - ccdc-csd-substructuresearch
       - ccdc-csd-resultstore
       - ccdc-csd-similaritysearch
-    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-searchservice-api:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-searchservice-api:3.0.0
 
   csd-request-entry:
     labels:
@@ -105,14 +105,14 @@ services:
     depends_on:
       - ccdc-csd-deposition
       - ccdc-csd-crystal-structure-export
-    image: ccdcrepository.azurecr.io/onsite/csd-request-entry-api:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/csd-request-entry-api:3.0.0
 
   ccdc-csd-formulasearch:
     labels:
       <<: *k8s-labels
     depends_on:
       - database-server
-    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-formulasearch-api:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-formulasearch-api:3.0.0
     environment:
       - FormulaSearchReadConnection=Server=database-server;Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=formula
 
@@ -122,14 +122,14 @@ services:
     depends_on:
       - database-server
       - ccdc-csd-reducedcell-calculation-service
-    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-unit-cell-search:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-unit-cell-search:3.0.0
     environment:
       - UnitCellSearchReadConnection=Server=database-server;Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=unitcell
 
   ccdc-csd-resultstore:
     labels:
       <<: *k8s-labels
-    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-resultstore-api:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-resultstore-api:3.0.0
     environment:
       - OrderedCachePassword=${CSD_CACHE_PASSWORD}
 
@@ -137,38 +137,38 @@ services:
     depends_on:
       - database-server
       - ccdc-csd-fingerprint
-    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-structure-similarity-search:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-structure-similarity-search:3.0.0
     environment:
       - StructureSimilaritySearchReadConnection=Server=database-server;Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=similarity
 
   ccdc-csd-fingerprint:
     labels:
       <<: *k8s-labels
-    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-fingerprint-service:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-fingerprint-service:3.0.0
     restart: unless-stopped
 
   ccdc-csd-substructure-filter:
     labels:
       <<: *k8s-labels
-    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-substructure-filter-service:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-substructure-filter-service:3.0.0
     restart: unless-stopped
 
   ccdc-csd-crystal-structure-export:
     labels:
       <<: *k8s-labels
-    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-crystal-structure-export-service:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-crystal-structure-export-service:3.0.0
     restart: unless-stopped
 
   ccdc-csd-reducedcell-calculation-service:
     labels:
       <<: *k8s-labels
-    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-reducedcell-calculation-service:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/ccdc-csd-reducedcell-calculation-service:3.0.0
     restart: unless-stopped
 
   webcsd-theory:
     labels:
       <<: *k8s-labels
-    image: ccdcrepository.azurecr.io/onsite/csd-theory:2.1.0
+    image: ccdcrepository.azurecr.io/onsite/csd-theory:3.0.0
     environment:
       - CCDC_LICENSING_CONFIGURATION=${CCDC_LICENSING_CONFIGURATION}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - csd-request-entry
     image: ccdcrepository.azurecr.io/onsite/webcsd:2.1.0
     ports:
-      - 80:80
+      - ${WEBCSD_PORT}:${WEBCSD_PORT}
     volumes:
       - ./userdata:/app/OnSite
     labels:
@@ -31,8 +31,6 @@ services:
       - CCDC_LICENSING_CONFIGURATION=${CCDC_LICENSING_CONFIGURATION}
     labels:
       <<: *k8s-labels
-    expose:
-      - 80
 
   redis:
     labels:
@@ -72,8 +70,6 @@ services:
       - ccdc-csd-deposition
     environment:
       - StructureSearchReadConnection=Server=database-server;Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=substructure
-    expose:
-      - 80
 
   ccdc-csd-deposition:
     labels:
@@ -83,8 +79,6 @@ services:
       - database-server
     environment:
       - CsdDepositionReadConnection=Server=database-server;Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=csd_schema
-    expose:
-      - 80
 
   ccdc-csd-textnumericsearch:
     labels:
@@ -94,8 +88,6 @@ services:
     image: ccdcrepository.azurecr.io/onsite/ccdc-csd-textnumericsearch-api:2.1.0
     environment:
       - CsdReadConnection=Server=database-server;Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=csd_schema
-    expose:
-      - 80
 
   ccdc-csd-searchservice:
     labels:
@@ -106,8 +98,6 @@ services:
       - ccdc-csd-resultstore
       - ccdc-csd-similaritysearch
     image: ccdcrepository.azurecr.io/onsite/ccdc-csd-searchservice-api:2.1.0
-    expose:
-      - 80
 
   csd-request-entry:
     labels:
@@ -116,8 +106,6 @@ services:
       - ccdc-csd-deposition
       - ccdc-csd-crystal-structure-export
     image: ccdcrepository.azurecr.io/onsite/csd-request-entry-api:2.1.0
-    expose:
-      - 80
 
   ccdc-csd-formulasearch:
     labels:
@@ -127,8 +115,6 @@ services:
     image: ccdcrepository.azurecr.io/onsite/ccdc-csd-formulasearch-api:2.1.0
     environment:
       - FormulaSearchReadConnection=Server=database-server;Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=formula
-    expose:
-      - 80
 
   ccdc-csd-unitcellsearch:
     labels:
@@ -139,8 +125,6 @@ services:
     image: ccdcrepository.azurecr.io/onsite/ccdc-csd-unit-cell-search:2.1.0
     environment:
       - UnitCellSearchReadConnection=Server=database-server;Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=unitcell
-    expose:
-      - 80
 
   ccdc-csd-resultstore:
     labels:
@@ -148,8 +132,6 @@ services:
     image: ccdcrepository.azurecr.io/onsite/ccdc-csd-resultstore-api:2.1.0
     environment:
       - OrderedCachePassword=${CSD_CACHE_PASSWORD}
-    expose:
-      - 80
 
   ccdc-csd-similaritysearch:
     depends_on:
@@ -163,32 +145,24 @@ services:
     labels:
       <<: *k8s-labels
     image: ccdcrepository.azurecr.io/onsite/ccdc-csd-fingerprint-service:2.1.0
-    expose:
-      - 80
     restart: unless-stopped
 
   ccdc-csd-substructure-filter:
     labels:
       <<: *k8s-labels
     image: ccdcrepository.azurecr.io/onsite/ccdc-csd-substructure-filter-service:2.1.0
-    expose:
-      - 80
     restart: unless-stopped
 
   ccdc-csd-crystal-structure-export:
     labels:
       <<: *k8s-labels
     image: ccdcrepository.azurecr.io/onsite/ccdc-csd-crystal-structure-export-service:2.1.0
-    expose:
-      - 80
     restart: unless-stopped
 
   ccdc-csd-reducedcell-calculation-service:
     labels:
       <<: *k8s-labels
     image: ccdcrepository.azurecr.io/onsite/ccdc-csd-reducedcell-calculation-service:2.1.0
-    expose:
-      - 80
     restart: unless-stopped
 
   webcsd-theory:
@@ -197,8 +171,6 @@ services:
     image: ccdcrepository.azurecr.io/onsite/csd-theory:2.1.0
     environment:
       - CCDC_LICENSING_CONFIGURATION=${CCDC_LICENSING_CONFIGURATION}
-    expose:
-      - 80
 
 volumes:
   csd_data: {}

--- a/sample.env
+++ b/sample.env
@@ -6,3 +6,6 @@ CCDC_LICENSING_CONFIGURATION=la-code;123456-123456-123456-123456-123456-123456;
 # Password for local database
 CSD_DB_PASSWORD=A password of your choosing
 CSD_CACHE_PASSWORD=A password of your choosing
+
+#You don't need to change this unless you want to run on a different port
+WEBCSD_PORT=80


### PR DESCRIPTION
Fix for issue where using our existing port config example would still run the containers on port 80 alongside the other port you specified. 