### PR TITLE
PLA-118 First pass at removing Redis and replacing with a search-store schema

### DIFF
--- a/Cloud-Installation/AWS/Serverless/webCSD-TD1.json
+++ b/Cloud-Installation/AWS/Serverless/webCSD-TD1.json
@@ -71,13 +71,22 @@
             "essential": true,
             "entryPoint": [],
             "command": [],
-            "environment": [],
+            "environment": [
+                {
+                    "name": "ResultStoreConnectionString",
+                    "value": "StructureSimilaritySearchReadConnection=Server=${database-server};Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=search-store"
+                }
+            ],
             "mountPoints": [],
             "volumesFrom": [],
             "secrets": [
                 {
-                    "name": "OrderedCachePassword",
-                    "valueFrom": "<ARN_CSD_CACHE_PASSWORD>"
+                    "name": "CSD_DB_PASSWORD",
+                    "valueFrom": "<ARN_CSD_DB_PASSWORD>"
+                },
+				{
+                    "name": "database-server",
+                    "valueFrom": "<DB_ENDPOINT_LINK> "
                 }
             ],
             "dnsServers": [],
@@ -112,39 +121,6 @@
             "dnsSearchDomains": [],
             "dockerSecurityOptions": [],
             "dockerLabels": {},
-            "logConfiguration": {
-                "logDriver": "awslogs",
-                "options": {
-                    "awslogs-group": "/ecs/<LOG_LOCATION>",
-                    "awslogs-region": "<AWS_REGION>",
-                    "awslogs-stream-prefix": "ecs"
-                }
-            },
-            "systemControls": []
-        },
-        {
-            "name": "redis",
-            "image": "redis:latest",
-            "cpu": 0,
-            "links": [],
-            "portMappings": [],
-            "essential": true,
-            "entryPoint": [],
-            "command": [
-                "redis-server --requirepass ${CSD_CACHE_PASSWORD}"
-            ],
-            "environment": [],
-            "mountPoints": [],
-            "volumesFrom": [],
-            "secrets": [
-                {
-                    "name": "CSD_CACHE_PASSWORD",
-                    "valueFrom": "<ARN_CSD_CACHE_PASSWORD>"
-                }
-            ],
-            "dnsServers": [],
-            "dnsSearchDomains": [],
-            "dockerSecurityOptions": [],
             "logConfiguration": {
                 "logDriver": "awslogs",
                 "options": {

--- a/Cloud-Installation/AWS/Serverless/webCSD-TD1.json
+++ b/Cloud-Installation/AWS/Serverless/webCSD-TD1.json
@@ -74,7 +74,7 @@
             "environment": [
                 {
                     "name": "ResultStoreConnectionString",
-                    "value": "StructureSimilaritySearchReadConnection=Server=${database-server};Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=search-store"
+                    "value": "Server=${database-server};Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=searchstore"
                 }
             ],
             "mountPoints": [],

--- a/Cloud-Installation/Azure/web-csd.json
+++ b/Cloud-Installation/Azure/web-csd.json
@@ -10,10 +10,6 @@
 			"defaultValue": "<CCDC_LICENSING_CONFIGURATION>",
 			"type": "securestring"
 		},
-		"OrderedCachePassword": {
-			"defaultValue": "<CSD_CACHE_PASSWORD>",
-			"type": "securestring"
-		},
 		"CSD_DB_PASSWORD": {
 			"defaultValue": "<CSD_DB_PASSWORD>",
 			"type": "securestring"
@@ -187,8 +183,8 @@
 						"image": "[concat(variables('ccdc-csd-resultstore-api_image'), ':', variables('ccdc-csd-resultstore-api_tag'))]",
 						"ports": [],
 						"environmentVariables": [{
-							"name": "OrderedCachePassword",
-							"value": "[parameters('OrderedCachePassword')]"
+							"name": "ResultStoreConnectionString",
+							"value": "[concat('Host=', parameters('CSD_DB_SERVER'), ';Port=', parameters('CSD_DB_PORT'), ';Username=', parameters('CSD_DB_USER'), '@', parameters('CSD_DB_SERVER'), ';Password=', parameters('CSD_DB_PASSWORD'), ';Database=csd-database;SearchPath=search-store')]"
 						}],
 						"resources": {
 							"requests": {

--- a/Cloud-Installation/Azure/web-csd.json
+++ b/Cloud-Installation/Azure/web-csd.json
@@ -184,7 +184,7 @@
 						"ports": [],
 						"environmentVariables": [{
 							"name": "ResultStoreConnectionString",
-							"value": "[concat('Host=', parameters('CSD_DB_SERVER'), ';Port=', parameters('CSD_DB_PORT'), ';Username=', parameters('CSD_DB_USER'), '@', parameters('CSD_DB_SERVER'), ';Password=', parameters('CSD_DB_PASSWORD'), ';Database=csd-database;SearchPath=search-store')]"
+							"value": "[concat('Host=', parameters('CSD_DB_SERVER'), ';Port=', parameters('CSD_DB_PORT'), ';Username=', parameters('CSD_DB_USER'), '@', parameters('CSD_DB_SERVER'), ';Password=', parameters('CSD_DB_PASSWORD'), ';Database=csd-database;SearchPath=searchstore')]"
 						}],
 						"resources": {
 							"requests": {

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ Here is an example of the .env file:
 ```
 CCDC_LICENSING_CONFIGURATION=la-code;123456-123456-123456-123456-123456-123456;
 CSD_DB_PASSWORD=A password of your choosing
-CSD_CACHE_PASSWORD=A password of your choosing
 WEBCSD_PORT=80
 ```
 

--- a/docker-compose.macromolecule-hub.yml
+++ b/docker-compose.macromolecule-hub.yml
@@ -36,16 +36,6 @@ services:
     labels:
       <<: *k8s-labels
 
-  redis:
-    labels:
-      <<: *k8s-labels
-    image: redis
-    user: redis
-    restart: always
-    command: redis-server --requirepass ${CSD_CACHE_PASSWORD}
-    expose:
-      - 6379
-
   database-server:
     labels:
       <<: *k8s-labels
@@ -143,11 +133,13 @@ services:
       - DatabaseConfiguration__Databases__1__SettingsKey=UnitCellPdbReadConnection
 
   ccdc-csd-resultstore:
+    depends_on:
+      - database-server
     labels:
       <<: *k8s-labels
     image: ccdcrepository.azurecr.io/onsite/ccdc-csd-resultstore-api:3.0.0
     environment:
-      - OrderedCachePassword=${CSD_CACHE_PASSWORD}
+      - ResultStoreConnectionString=database-server;Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=search-store
 
   ccdc-csd-similaritysearch:
     depends_on:

--- a/docker-compose.macromolecule-hub.yml
+++ b/docker-compose.macromolecule-hub.yml
@@ -139,7 +139,7 @@ services:
       <<: *k8s-labels
     image: ccdcrepository.azurecr.io/onsite/ccdc-csd-resultstore-api:3.0.0
     environment:
-      - ResultStoreConnectionString=database-server;Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=search-store
+      - ResultStoreConnectionString=Server=database-server;Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=searchstore
 
   ccdc-csd-similaritysearch:
     depends_on:

--- a/docker-compose.port-configuration.yml
+++ b/docker-compose.port-configuration.yml
@@ -27,11 +27,7 @@ services:
       - ${WEBCSD_PORT}
     healthcheck: 
       test: "curl --fail --silent --show-error --connect-timeout 5 --max-time 5 http://localhost:${WEBCSD_PORT}/health/ready"
-
-  redis:
-    expose:
-      - 6379
-  
+ 
   database-server:
     expose:
       - 5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,16 +32,6 @@ services:
     labels:
       <<: *k8s-labels
 
-  redis:
-    labels:
-      <<: *k8s-labels
-    image: redis
-    user: redis
-    restart: always
-    command: redis-server --requirepass ${CSD_CACHE_PASSWORD}
-    expose:
-      - 6379
-
   database-server:
     labels:
       <<: *k8s-labels
@@ -127,11 +117,13 @@ services:
       - UnitCellSearchReadConnection=Server=database-server;Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=unitcell
 
   ccdc-csd-resultstore:
+    depends_on:
+      - database-server
     labels:
       <<: *k8s-labels
     image: ccdcrepository.azurecr.io/onsite/ccdc-csd-resultstore-api:3.0.0
     environment:
-      - OrderedCachePassword=${CSD_CACHE_PASSWORD}
+      - ResultStoreConnectionString=database-server;Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=search-store
 
   ccdc-csd-similaritysearch:
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,7 +123,7 @@ services:
       <<: *k8s-labels
     image: ccdcrepository.azurecr.io/onsite/ccdc-csd-resultstore-api:3.0.0
     environment:
-      - ResultStoreConnectionString=database-server;Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=search-store
+      - ResultStoreConnectionString=Server=database-server;Port=5432;Database=csd-database;User Id=postgres;Password=${CSD_DB_PASSWORD};SearchPath=searchstore
 
   ccdc-csd-similaritysearch:
     depends_on:

--- a/sample.env
+++ b/sample.env
@@ -5,7 +5,6 @@ CCDC_LICENSING_CONFIGURATION=la-code;123456-123456-123456-123456-123456-123456;
 
 # Password for local database
 CSD_DB_PASSWORD=A password of your choosing
-CSD_CACHE_PASSWORD=A password of your choosing
 
 #You don't need to change this unless you want to run on a different port
 WEBCSD_PORT=80


### PR DESCRIPTION
This removes redis and replaces it with a search-store schema within the main postgres database.

Currently there isn't a matching change to the database container to make it contain this schema, so the system fails to start. These changes also need testing in all three environments.